### PR TITLE
First pass of DCOM call cancellation mechanism for DA client

### DIFF
--- a/src/Technosoftware/DaAeHdaClient/Com/Da/Server.cs
+++ b/src/Technosoftware/DaAeHdaClient/Com/Da/Server.cs
@@ -26,7 +26,10 @@ using System.Threading;
 using System.Collections;
 using System.Globalization;
 using System.Runtime.InteropServices;
+
 using Technosoftware.DaAeHdaClient.Da;
+using Technosoftware.DaAeHdaClient.Utilities;
+
 using OpcRcw.Da;
 
 #endregion
@@ -162,13 +165,18 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
 
                 // invoke COM method.
                 try
-                {
+                {                   
                     IOPCServer server = BeginComCall<IOPCServer>(methodName, true);
 
                     (server).GetErrorString(
                         resultId.Code,
                         Technosoftware.DaAeHdaClient.Com.Interop.GetLocale(locale),
                         out var errorText);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
 
                     return errorText;
                 }
@@ -179,7 +187,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                 }
                 finally
                 {
-                    EndComCall(methodName);
+                    EndComCall(methodName);                   
                 }
             }
         }
@@ -228,9 +236,14 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
 
                 // invoke COM method.
                 try
-                {
+                {                  
                     IOPCServer server = BeginComCall<IOPCServer>(methodName, true);
                     (server).GetStatus(out pStatus);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
                 }
                 catch (Exception e)
                 {
@@ -278,10 +291,10 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                 IntPtr pQualities = IntPtr.Zero;
                 IntPtr pTimestamps = IntPtr.Zero;
                 IntPtr pErrors = IntPtr.Zero;
-
+                                
                 // invoke COM method.
                 try
-                {
+                {              
                     IOPCItemIO server = BeginComCall<IOPCItemIO>(methodName, true);
                     server.Read(
                          count,
@@ -291,6 +304,12 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                          out pQualities,
                          out pTimestamps,
                          out pErrors);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
+
                 }
                 catch (Exception e)
                 {
@@ -404,13 +423,18 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
 
                 // invoke COM method.
                 try
-                {
+                {                
                     IOPCItemIO server = BeginComCall<IOPCItemIO>(methodName, true);
                     server.WriteVQT(
                         count,
                         itemIDs,
                         values,
                         out pErrors);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
                 }
                 catch (Exception e)
                 {
@@ -475,7 +499,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                 int revisedUpdateRate = 0;
 
                 GCHandle hDeadband = GCHandle.Alloc(result.Deadband, GCHandleType.Pinned);
-
+                              
                 // invoke COM method.
                 try
                 {
@@ -492,6 +516,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                         out revisedUpdateRate,
                         ref iid,
                         out group);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
                 }
                 catch (Exception e)
                 {
@@ -508,15 +537,21 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                 }
 
                 if (group == null) throw new OpcResultException(OpcResult.E_FAIL, "The subscription  was not created.");
-
+               
                 methodName = "IOPCGroupStateMgt2.SetKeepAlive";
 
                 // set the keep alive rate if requested.
                 try
-                {
+                {                 
                     int keepAlive = 0;
                     IOPCGroupStateMgt2 comObject = BeginComCall<IOPCGroupStateMgt2>(group, methodName, true);
                     comObject.SetKeepAlive(result.KeepAlive, out keepAlive);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
+
                     result.KeepAlive = keepAlive;
                 }
                 catch (Exception e1)
@@ -526,9 +561,9 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                 }
                 finally
                 {
-                    EndComCall(methodName);
+                    EndComCall(methodName);                   
                 }
-
+              
                 // save server handle.
                 result.ServerHandle = serverHandle;
 
@@ -583,9 +618,14 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
 
                 // invoke COM method.
                 try
-                {
+                {                 
                     IOPCServer server = BeginComCall<IOPCServer>(methodName, true);
                     server.RemoveGroup((int)state.ServerHandle, 0);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
                 }
                 catch (Exception e)
                 {
@@ -594,7 +634,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                 }
                 finally
                 {
-                    EndComCall(methodName);
+                    EndComCall(methodName);                   
                 }
             }
         }
@@ -629,7 +669,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
 
                 // invoke COM method.
                 try
-                {
+                {                    
                     IOPCBrowse server = BeginComCall<IOPCBrowse>(methodName, true);
                     server.Browse(
                              (itemId != null && itemId.ItemName != null) ? itemId.ItemName : "",
@@ -645,6 +685,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                          out moreElements,
                          out count,
                          out pElements);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
                 }
                 catch (Exception e)
                 {
@@ -653,7 +698,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                 }
                 finally
                 {
-                    EndComCall(methodName);
+                    EndComCall(methodName);                    
                 }
 
                 // unmarshal results.
@@ -714,7 +759,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
 
                 // invoke COM method.
                 try
-                {
+                {                   
                     IOPCBrowse server = BeginComCall<IOPCBrowse>(methodName, true);
                     server.Browse(
                         (itemID != null && itemID.ItemName != null) ? itemID.ItemName : "",
@@ -730,6 +775,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                         out moreElements,
                         out count,
                         out pElements);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
                 }
                 catch (Exception e)
                 {
@@ -738,7 +788,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                 }
                 finally
                 {
-                    EndComCall(methodName);
+                    EndComCall(methodName);                    
                 }
 
                 // unmarshal results.
@@ -791,7 +841,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
 
                 // invoke COM method.
                 try
-                {
+                {                   
                     IOPCBrowse server = BeginComCall<IOPCBrowse>(methodName, true);
                     server.GetProperties(
                           itemIds.Length,
@@ -800,6 +850,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                           (propertyIDs != null) ? propertyIDs.Length : 0,
                           Interop.GetPropertyIDs(propertyIDs),
                           out pPropertyLists);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
                 }
                 catch (Exception e)
                 {
@@ -807,8 +862,8 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                     throw Technosoftware.DaAeHdaClient.Com.Interop.CreateException(methodName, e);
                 }
                 finally
-                {
-                    EndComCall(methodName);
+                {                   
+                    EndComCall(methodName);                    
                 }
 
                 // unmarshal results.

--- a/src/Technosoftware/DaAeHdaClient/Com/Da/Subscription.cs
+++ b/src/Technosoftware/DaAeHdaClient/Com/Da/Subscription.cs
@@ -246,7 +246,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                     int localeID = 0;
                     int clientHandle = 0;
                     int serverHandle = 0;
-
+              
                     IOPCGroupStateMgt subscription = BeginComCall<IOPCGroupStateMgt>(methodName, true);
                     subscription.GetState(
                         out updateRate,
@@ -257,6 +257,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                         out localeID,
                         out clientHandle,
                         out serverHandle);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
 
                     state.Name = name;
                     state.ServerHandle = serverHandle;
@@ -283,10 +288,16 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                 {
                     methodName = "IOPCGroupStateMgt2.GetKeepAlive";
                     try
-                    {
+                    {                
                         int keepAlive = 0;
                         IOPCGroupStateMgt2 subscription = BeginComCall<IOPCGroupStateMgt2>(methodName, true);
                         subscription.GetKeepAlive(out keepAlive);
+
+                        if (DCOMCallWatchdog.IsCancelled)
+                        {
+                            throw new Exception($"{methodName} call was cancelled due to response timeout");
+                        }
+
                         state.KeepAlive = keepAlive;
                     }
                     catch (Exception e)
@@ -316,7 +327,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
             if (subscription_ == null) throw new NotConnectedException();
 
             lock (lock_)
-            {
+            {               
                 string methodName = "IOPCGroupStateMgt.SetName";
                 // update the subscription name.
                 if ((masks & (int)TsCDaStateMask.Name) != 0 && state.Name != name_)
@@ -325,6 +336,12 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                     {
                         IOPCGroupStateMgt subscription = BeginComCall<IOPCGroupStateMgt>(methodName, true);
                         subscription.SetName(state.Name);
+
+                        if (DCOMCallWatchdog.IsCancelled)
+                        {
+                            throw new Exception($"{methodName} call was cancelled due to response timeout");
+                        }
+
                         name_ = state.Name;
                     }
                     catch (Exception e)
@@ -360,7 +377,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
 
                 methodName = "IOPCGroupStateMgt.SetState";
                 try
-                {
+                {                
                     IOPCGroupStateMgt subscription = BeginComCall<IOPCGroupStateMgt>(methodName, true);
                     subscription.SetState(
                         ((masks & (int)TsCDaStateMask.UpdateRate) != 0) ? hUpdateRate.AddrOfPinnedObject() : IntPtr.Zero,
@@ -370,6 +387,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                         ((masks & (int)TsCDaStateMask.Deadband) != 0) ? hDeadband.AddrOfPinnedObject() : IntPtr.Zero,
                         ((masks & (int)TsCDaStateMask.Locale) != 0) ? hLocale.AddrOfPinnedObject() : IntPtr.Zero,
                         IntPtr.Zero);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
                 }
                 catch (Exception e)
                 {
@@ -392,9 +414,14 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
 
                     methodName = "IOPCGroupStateMgt2.SetKeepAlive";
                     try
-                    {
+                    {           
                         IOPCGroupStateMgt2 subscription = BeginComCall<IOPCGroupStateMgt2>(methodName, true);
                         subscription.SetKeepAlive(state.KeepAlive, out keepAlive);
+
+                        if (DCOMCallWatchdog.IsCancelled)
+                        {
+                            throw new Exception($"{methodName} call was cancelled due to response timeout");
+                        }
                     }
                     catch (Exception e)
                     {
@@ -449,13 +476,18 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
 
                     string methodName = "IOPCItemMgt.AddItems";
                     try
-                    {
+                    {          
                         IOPCItemMgt subscription = BeginComCall<IOPCItemMgt>(methodName, true);
                         subscription.AddItems(
                             count,
                             definitions,
                             out pResults,
                             out pErrors);
+
+                        if (DCOMCallWatchdog.IsCancelled)
+                        {
+                            throw new Exception($"{methodName} call was cancelled due to response timeout");
+                        }
                     }
                     catch (Exception e)
                     {
@@ -614,9 +646,14 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
 
                 string methodName = "IOPCItemMgt.RemoveItems";
                 try
-                {
+                {         
                     IOPCItemMgt subscription = BeginComCall<IOPCItemMgt>(methodName, true);
                     subscription.RemoveItems(itemIDs.Length, serverHandles, out pErrors);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
                 }
                 catch (Exception e)
                 {
@@ -950,6 +987,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                     {
                         IOPCAsyncIO2 subscription = BeginComCall<IOPCAsyncIO2>(methodName, true);
                         subscription.Cancel2(((Request)request).CancelID);
+
+                        if (DCOMCallWatchdog.IsCancelled)
+                        {
+                            throw new Exception($"{methodName} call was cancelled due to response timeout");
+                        }
                     }
                     catch (Exception e)
                     {
@@ -978,6 +1020,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                     int cancelID = 0;
                     IOPCAsyncIO3 subscription = BeginComCall<IOPCAsyncIO3>(methodName, true);
                     subscription.RefreshMaxAge(Int32.MaxValue, ++_counter, out cancelID);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
                 }
                 catch (Exception e)
                 {
@@ -1025,6 +1072,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                 {
                     IOPCAsyncIO3 subscription = BeginComCall<IOPCAsyncIO3>(methodName, true);
                     subscription.RefreshMaxAge(0, (int)internalRequest.RequestID, out cancelID);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
                 }
                 catch (Exception e)
                 {
@@ -1060,6 +1112,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                 {
                     IOPCAsyncIO3 subscription = BeginComCall<IOPCAsyncIO3>(methodName, true);
                     subscription.SetEnable((enabled) ? 1 : 0);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
                 }
                 catch (Exception e)
                 {
@@ -1088,6 +1145,12 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                     int enabled = 0;
                     IOPCAsyncIO3 subscription = BeginComCall<IOPCAsyncIO3>(methodName, true);
                     subscription.GetEnable(out enabled);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
+
                     return enabled != 0;
                 }
                 catch (Exception e)
@@ -1141,6 +1204,8 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                     }
                 }
 
+                DCOMCallWatchdog.Set();
+
                 return comObject;
             }
         }
@@ -1167,6 +1232,8 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
             lock (lock_)
             {
                 outstandingCalls_--;
+
+                DCOMCallWatchdog.Reset();
             }
         }
         #endregion
@@ -1205,6 +1272,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                     out pQualities,
                     out pTimestamps,
                     out pErrors);
+
+                if (DCOMCallWatchdog.IsCancelled)
+                {
+                    throw new Exception($"{methodName} call was cancelled due to response timeout");
+                }
 
                 // unmarshal output parameters.
                 object[] values = Com.Interop.GetVARIANTs(ref pValues, itemIDs.Length, true);
@@ -1273,6 +1345,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                     values,
                     out pErrors);
 
+                if (DCOMCallWatchdog.IsCancelled)
+                {
+                    throw new Exception($"{methodName} call was cancelled due to response timeout");
+                }
+
                 // unmarshal results.
                 int[] errors = Technosoftware.DaAeHdaClient.Com.Interop.GetInt32s(ref pErrors, itemIDs.Length, true);
 
@@ -1338,6 +1415,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                     out cancelID,
                     out pErrors);
 
+                if (DCOMCallWatchdog.IsCancelled)
+                {
+                    throw new Exception($"{methodName} call was cancelled due to response timeout");
+                }
+
                 // unmarshal output parameters.
                 int[] errors = Technosoftware.DaAeHdaClient.Com.Interop.GetInt32s(ref pErrors, itemIDs.Length, true);
 
@@ -1402,6 +1484,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                     requestID,
                     out cancelID,
                     out pErrors);
+
+                if (DCOMCallWatchdog.IsCancelled)
+                {
+                    throw new Exception($"{methodName} call was cancelled due to response timeout");
+                }
 
                 // unmarshal results.
                 int[] errors = Technosoftware.DaAeHdaClient.Com.Interop.GetInt32s(ref pErrors, itemIDs.Length, true);
@@ -1481,6 +1568,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                     datatypes,
                     out pErrors);
 
+                if (DCOMCallWatchdog.IsCancelled)
+                {
+                    throw new Exception($"{methodName} call was cancelled due to response timeout");
+                }
+
                 // check for individual item errors.
                 int[] errors = Technosoftware.DaAeHdaClient.Com.Interop.GetInt32s(ref pErrors, handles.Length, true);
 
@@ -1541,6 +1633,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                     handles,
                     (active) ? 1 : 0,
                     out pErrors);
+
+                if (DCOMCallWatchdog.IsCancelled)
+                {
+                    throw new Exception($"{methodName} call was cancelled due to response timeout");
+                }
 
                 // check for individual item errors.
                 int[] errors = Technosoftware.DaAeHdaClient.Com.Interop.GetInt32s(ref pErrors, handles.Length, true);
@@ -1636,6 +1733,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                     deadbands,
                     out pErrors);
 
+                if (DCOMCallWatchdog.IsCancelled)
+                {
+                    throw new Exception($"{methodName} call was cancelled due to response timeout");
+                }
+
                 // check for individual item errors.
                 int[] errors = Technosoftware.DaAeHdaClient.Com.Interop.GetInt32s(ref pErrors, handles.Length, true);
 
@@ -1693,6 +1795,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                     handles.Length,
                     handles,
                     out pErrors);
+
+                if (DCOMCallWatchdog.IsCancelled)
+                {
+                    throw new Exception($"{methodName} call was cancelled due to response timeout");
+                }
 
                 // check for individual item errors.
                 int[] errors = Technosoftware.DaAeHdaClient.Com.Interop.GetInt32s(ref pErrors, handles.Length, true);
@@ -1792,6 +1899,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                     out pResults,
                     out pErrors);
 
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
+
                     // check for individual item errors.
                     int[] results = Technosoftware.DaAeHdaClient.Com.Interop.GetInt32s(ref pResults, handles.Length, true);
                     int[] errors = Technosoftware.DaAeHdaClient.Com.Interop.GetInt32s(ref pErrors, handles.Length, true);
@@ -1861,6 +1973,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                     handles.Length,
                     handles,
                     out pErrors);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
 
                     // check for individual item errors.
                     int[] errors = Technosoftware.DaAeHdaClient.Com.Interop.GetInt32s(ref pErrors, handles.Length, true);
@@ -1972,6 +2089,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da
                     handles,
                     enabled,
                     out pErrors);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
 
                     // check for individual item errors.
                     int[] errors = Technosoftware.DaAeHdaClient.Com.Interop.GetInt32s(ref pErrors, handles.Length, true);

--- a/src/Technosoftware/DaAeHdaClient/Com/Da20/Server.cs
+++ b/src/Technosoftware/DaAeHdaClient/Com/Da20/Server.cs
@@ -27,6 +27,8 @@ using System.Runtime.InteropServices;
 
 using Technosoftware.DaAeHdaClient.Da;
 using Technosoftware.DaAeHdaClient.Com.Da;
+using Technosoftware.DaAeHdaClient.Utilities;
+
 using OpcRcw.Da;
 using OpcRcw.Comn;
 
@@ -125,7 +127,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                 // create a global subscription required for various item level operations.
                 methodName = "IOPCServer.AddGroup";
                 try
-                {
+                {                  
                     // add the subscription.
                     int revisedUpdateRate = 0;
                     Guid iid = typeof(IOPCItemMgt).GUID;
@@ -143,6 +145,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                         out revisedUpdateRate,
                         ref iid,
                         out subscription_);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
                 }
                 catch (Exception e)
                 {
@@ -152,7 +159,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                 }
                 finally
                 {
-                    EndComCall(methodName);
+                    EndComCall(methodName);                  
                 }
             }
         }
@@ -242,7 +249,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                         string methodName = "IOPCItemMgt.SetActiveState";
                         // items must be active for cache reads.
                         try
-                        {
+                        {                           
                             // create list of server handles.
                             int[] serverHandles = new int[cacheResults.Count];
 
@@ -262,6 +269,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
 
                             // free error array.
                             Marshal.FreeCoTaskMem(pErrors);
+
+                            if (DCOMCallWatchdog.IsCancelled)
+                            {
+                                throw new Exception($"{methodName} call was cancelled due to response timeout");
+                            }
                         }
                         catch (Exception e)
                         {
@@ -374,13 +386,18 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                         // write item values.
                         string methodName = "IOPCSyncIO.Write";
                         try
-                        {
+                        {                   
                             IOPCSyncIO subscription = BeginComCall<IOPCSyncIO>(subscription_, methodName, true);
                             subscription.Write(
                                 writeItems.Count,
                                 serverHandles,
                                 values,
                                 out pErrors);
+
+                            if (DCOMCallWatchdog.IsCancelled)
+                            {
+                                throw new Exception($"{methodName} call was cancelled due to response timeout");
+                            }
                         }
                         catch (Exception e)
                         {
@@ -629,7 +646,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
             ((IOPCCommon)server_).GetLocaleID(out localeID);
 
             GCHandle hLocale = GCHandle.Alloc(localeID, GCHandleType.Pinned);
-
+                     
             string methodName = "IOPCGroupStateMgt.SetState";
             try
             {
@@ -645,6 +662,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                     IntPtr.Zero,
                     hLocale.AddrOfPinnedObject(),
                     IntPtr.Zero);
+
+                if (DCOMCallWatchdog.IsCancelled)
+                {
+                    throw new Exception($"{methodName} call was cancelled due to response timeout");
+                }
             }
             catch (Exception e)
             {
@@ -654,9 +676,9 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
             finally
             {
                 if (hLocale.IsAllocated) hLocale.Free();
-                EndComCall(methodName);
+                EndComCall(methodName);                
             }
-
+         
             // add items to subscription.
             methodName = "IOPCItemMgt.AddItems";
             try
@@ -667,6 +689,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                     definitions,
                     out pResults,
                     out pErrors);
+
+                if (DCOMCallWatchdog.IsCancelled)
+                {
+                    throw new Exception($"{methodName} call was cancelled due to response timeout");
+                }
             }
             catch (Exception e)
             {
@@ -678,7 +705,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                 EndComCall(methodName);
                 if (hLocale.IsAllocated) hLocale.Free();
             }
-
+          
             // unmarshal output parameters.
             int[] serverHandles = Technosoftware.DaAeHdaClient.Com.Da.Interop.GetItemResults(ref pResults, count, true);
             int[] errors = Utilities.Interop.GetInt32s(ref pErrors, count, true);
@@ -733,12 +760,17 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
 
                 string methodName = "IOPCItemMgt.RemoveItems";
                 try
-                {
+                {              
                     IOPCItemMgt subscription = BeginComCall<IOPCItemMgt>(subscription_, methodName, true);
                     ((IOPCItemMgt)subscription).RemoveItems(
                         handles.Count,
                         (int[])handles.ToArray(typeof(int)),
                         out pErrors);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
 
                 }
                 catch (Exception e)
@@ -781,7 +813,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
 
             string methodName = "IOPCSyncIO.Read";
             try
-            {
+            {         
                 IOPCSyncIO subscription = BeginComCall<IOPCSyncIO>(subscription_, methodName, true);
                 subscription.Read(
                     (cache) ? OPCDATASOURCE.OPC_DS_CACHE : OPCDATASOURCE.OPC_DS_DEVICE,
@@ -789,6 +821,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                     serverHandles,
                     out pValues,
                     out pErrors);
+
+                if (DCOMCallWatchdog.IsCancelled)
+                {
+                    throw new Exception($"{methodName} call was cancelled due to response timeout");
+                }
             }
             catch (Exception e)
             {
@@ -874,7 +911,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
 
             string methodName = "IOPCItemProperties.QueryAvailableProperties";
             try
-            {
+            {          
                 IOPCItemProperties server = BeginComCall<IOPCItemProperties>(methodName, true);
                 server.QueryAvailableProperties(
                     itemID,
@@ -882,6 +919,12 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                     out pPropertyIDs,
                     out pDescriptions,
                     out pDataTypes);
+
+                if (DCOMCallWatchdog.IsCancelled)
+                {
+                    throw new Exception($"{methodName} call was cancelled due to response timeout");
+                }
+
             }
             catch (Exception e)
             {
@@ -891,7 +934,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
             finally
             {
                 EndComCall(methodName);
-                // free returned error array.
+                // free returned error array.                
             }
 
             // unmarshal results.
@@ -943,13 +986,13 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                 // lookup item ids.
                 IntPtr pItemIDs = IntPtr.Zero;
                 IntPtr pErrors = IntPtr.Zero;
-
+                             
                 ((IOPCItemProperties)server_).LookupItemIDs(
                     itemID,
                     properties.Length,
                     propertyIDs,
                     out pItemIDs,
-                    out pErrors);
+                    out pErrors);              
 
                 // unmarshal results.
                 string[] itemIDs = Utilities.Interop.GetUnicodeStrings(ref pItemIDs, properties.Length, true);
@@ -967,7 +1010,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                     }
                 }
             }
-            catch
+            catch (Exception e)
             {
                 // set item ids to null for all properties.
                 foreach (TsCDaItemProperty property in properties)
@@ -1144,7 +1187,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                             }
                             catch (Exception)
                             {
-                                break;
+                                break;                                                               
                             }
                         }
                     }
@@ -1259,6 +1302,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
         private void DetectAndSaveSeparators(string browseName, string itemID)
         {
             if (!itemID.EndsWith(browseName))
+            {
+                return;
+            }
+
+            if (string.Compare(itemID, browseName, true) == 0)
             {
                 return;
             }
@@ -1454,7 +1502,7 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                          (itemID != null) ? itemID.ItemName : null,
                          filters,
                          branches,
-             namespaceType == OPCNAMESPACETYPE.OPC_NS_FLAT);
+                         namespaceType == OPCNAMESPACETYPE.OPC_NS_FLAT);
             }
             else
             {

--- a/src/Technosoftware/DaAeHdaClient/Com/Da20/Subscription.cs
+++ b/src/Technosoftware/DaAeHdaClient/Com/Da20/Subscription.cs
@@ -26,6 +26,8 @@ using System.Collections;
 
 using Technosoftware.DaAeHdaClient.Da;
 using Technosoftware.DaAeHdaClient.Com.Da;
+using Technosoftware.DaAeHdaClient.Utilities;
+
 using OpcRcw.Da;
 #endregion
 
@@ -82,6 +84,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                         out clientHandle,
                         out serverHandle);
 
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
+
                     state.Name = name;
                     state.ServerHandle = serverHandle;
                     state.Active = active != 0;
@@ -123,6 +130,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                     int cancelID = 0;
                     IOPCAsyncIO2 subscription = BeginComCall<IOPCAsyncIO2>(methodName, true);
                     subscription.Refresh2(OPCDATASOURCE.OPC_DS_CACHE, ++_counter, out cancelID);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
                 }
                 catch (Exception e)
                 {
@@ -149,6 +161,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                 {
                     IOPCAsyncIO2 subscription = BeginComCall<IOPCAsyncIO2>(methodName, true);
                     subscription.SetEnable((enabled) ? 1 : 0);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
                 }
                 catch (Exception e)
                 {
@@ -176,6 +193,12 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                     int enabled = 0;
                     IOPCAsyncIO2 subscription = BeginComCall<IOPCAsyncIO2>(methodName, true);
                     subscription.GetEnable(out enabled);
+
+                    if (DCOMCallWatchdog.IsCancelled)
+                    {
+                        throw new Exception($"{methodName} call was cancelled due to response timeout");
+                    }
+
                     return enabled != 0;
                 }
                 catch (Exception e)
@@ -264,6 +287,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                     serverHandles,
                     out pValues,
                     out pErrors);
+
+                if (DCOMCallWatchdog.IsCancelled)
+                {
+                    throw new Exception($"{methodName} call was cancelled due to response timeout");
+                }
             }
             catch (Exception e)
             {
@@ -355,6 +383,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                     serverHandles,
                     values,
                     out pErrors);
+
+                if (DCOMCallWatchdog.IsCancelled)
+                {
+                    throw new Exception($"{methodName} call was cancelled due to response timeout");
+                }
             }
             catch (Exception e)
             {
@@ -414,6 +447,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                     requestID,
                     out cancelID,
                     out pErrors);
+
+                if (DCOMCallWatchdog.IsCancelled)
+                {
+                    throw new Exception($"{methodName} call was cancelled due to response timeout");
+                }
 
                 // unmarshal output parameters.
                 int[] errors = Utilities.Interop.GetInt32s(ref pErrors, itemIDs.Length, true);
@@ -508,6 +546,11 @@ namespace Technosoftware.DaAeHdaClient.Com.Da20
                     requestID,
                     out cancelID,
                     out pErrors);
+
+                if (DCOMCallWatchdog.IsCancelled)
+                {
+                    throw new Exception($"{methodName} call was cancelled due to response timeout");
+                }
 
                 // unmarshal results.
                 int[] errors = Utilities.Interop.GetInt32s(ref pErrors, validItems.Count, true);

--- a/src/Technosoftware/DaAeHdaClient/Interfaces/IOpcServer.cs
+++ b/src/Technosoftware/DaAeHdaClient/Interfaces/IOpcServer.cs
@@ -79,7 +79,21 @@ namespace Technosoftware.DaAeHdaClient
 		/// <param name="resultId">The result code identifier.</param>
 		/// <returns>A message localized for the best match for the requested locale.</returns>
 		string GetErrorText(string locale, OpcResult resultId);
-	}
+
+        /// <summary>
+        /// Allows control of DCOM callbacks to the server - by default DCOM calls will wait the default DCOM timeout
+        /// to fail - this method allows for tigher control of the timeout to wait. Note that DOCM calls can only be controlled
+        /// on a COM Single Threaded Apartment thread - use [STAThread] attribute on your application entry point or use Thread SetThreadApartment
+        /// before the thread the server is operating on is created to STA.
+        /// </summary>
+        /// <param name="timeout">The DCOM call timeout</param>
+        void EnableDCOMCallCancellation(TimeSpan timeout);
+
+        /// <summary>
+        /// Disables control of DCOM call to the server
+        /// </summary>
+        void DisableDCOMCallCancellation();
+    }
 
 	/// <summary>
 	/// A delegate to receive shutdown notifications from the server. This delegate can

--- a/src/Technosoftware/DaAeHdaClient/OpcServer.cs
+++ b/src/Technosoftware/DaAeHdaClient/OpcServer.cs
@@ -27,6 +27,8 @@ using System.Globalization;
 using System.Resources;
 using System.Reflection;
 using System.Runtime.Serialization;
+
+using Technosoftware.DaAeHdaClient.Utilities;
 #endregion
 
 namespace Technosoftware.DaAeHdaClient
@@ -134,7 +136,7 @@ namespace Technosoftware.DaAeHdaClient
                 {
                     // ignored
                 }
-
+                              
                 Server = null;
             }
         }
@@ -626,6 +628,27 @@ namespace Technosoftware.DaAeHdaClient
 
             return Server.GetErrorText(locale ?? locale_, resultId);
         }
+
+        /// <summary>
+        /// Allows cancellation control of DCOM callbacks to the server - by default DCOM calls will wait the default DCOM timeout
+        /// to fail - this method allows for tigher control of the timeout to wait. Note that DOCM calls can only be controlled
+        /// on a COM Single Threaded Apartment thread - use [STAThread] attribute on your application entry point or use Thread SetThreadApartment
+        /// before the thread the server is operating on is created to STA.
+        /// </summary>
+        /// <param name="timeout">The DCOM call timeout - uses the default timeout if not specified</param>
+        public void EnableDCOMCallCancellation(TimeSpan timeout = default)
+        {
+            DCOMCallWatchdog.Enable(timeout);
+        }
+
+        /// <summary>
+        /// Disables cancellation control of DCOM calls to the server
+        /// </summary>
+        public void DisableDCOMCallCancellation()
+        {
+            DCOMCallWatchdog.Disable();
+        }
+
         #endregion
     }
 
@@ -777,6 +800,25 @@ namespace Technosoftware.DaAeHdaClient
         public BadInternalErrorException(string message, Exception innerException) : base(message, innerException) { }
         /// <remarks/>
         protected BadInternalErrorException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+    }
+
+    /// <summary>
+    /// Exception that is raise when a DCOM call is cancelled due to timeout
+    /// </summary>
+    /// 
+    [Serializable]
+    public class DCOMCallCancelledException : ApplicationException
+    {
+        private const string Default = "The current pending DCOM call was cancelled";
+        /// <remarks/>
+        public DCOMCallCancelledException() : base(Default) { }
+        /// <remarks/>
+        public DCOMCallCancelledException(string message) : base(message) { }
+        /// <remarks/>
+        public DCOMCallCancelledException(string message, Exception innerException) : base(message, innerException) { }
+        /// <remarks/>
+        protected DCOMCallCancelledException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+        
     }
 
 }

--- a/src/Technosoftware/DaAeHdaClient/Technosoftware.DaAeHdaClient.csproj
+++ b/src/Technosoftware/DaAeHdaClient/Technosoftware.DaAeHdaClient.csproj
@@ -43,6 +43,11 @@
     <DefineConstants>TRACE;NETCORE</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net462|AnyCPU'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />

--- a/src/Technosoftware/DaAeHdaClient/Utilities/DCOMCallWatchdog.cs
+++ b/src/Technosoftware/DaAeHdaClient/Utilities/DCOMCallWatchdog.cs
@@ -1,0 +1,388 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Technosoftware.DaAeHdaClient.Com;
+
+namespace Technosoftware.DaAeHdaClient.Utilities
+{
+    internal enum DCOMWatchdogResult
+    {
+        /// <summary>
+        /// Watchdog has not been set/there is no result
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// The Set/Reset cycle was manually completed i.e. the DCOM call did not timeout
+        /// </summary>
+        Completed,
+        /// <summary>
+        /// No Reset call occurred with the timeout period thus the current DCOM call was automatically cancelled
+        /// </summary>
+        TimedOut,
+        /// <summary>
+        /// The current DCOM call was manually cancelled
+        /// </summary>
+        ManuallyCancelled
+    }
+
+    /// <summary>
+    /// Watchdog mechanism to allow for cancellation of DCOM calls. Note that this mechanism will only work for a STA thread apartment - the thread on which
+    /// the watchdog is Set and DCOM calls are made have to be the same thread and the thread apartment model has to be set to STA.
+    /// </summary>
+    internal static class DCOMCallWatchdog
+    {
+        #region Fields
+        public const int DEFAULT_TIMEOUT_SECONDS = 10;
+
+        private static object watchdogLock_ = new object();
+        private static uint watchDogThreadID_;
+        private static bool isCancelled_;
+        private static TimeSpan timeout_ = TimeSpan.Zero; //disabled by default
+        private static Task watchdogTask_;
+        private static DCOMWatchdogResult lastWatchdogResult_ = DCOMWatchdogResult.None;
+        private static DateTime setStart_;
+        
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// The result of the last watchdog set/reset operation
+        /// </summary>
+        public static DCOMWatchdogResult LastWatchdogResult
+        {
+            get { return lastWatchdogResult_; }
+        }
+
+        /// <summary>
+        /// The current native thread ID on which the watchdog has been enabled
+        /// </summary>
+        public static uint WatchDogThreadID
+        {
+            get => watchDogThreadID_;
+        }
+
+        /// <summary>
+        /// Indicates if the watchdog mechanism is active or not
+        /// </summary>
+        public static bool IsEnabled
+        {
+            get => timeout_ != TimeSpan.Zero;
+        }
+
+        /// <summary>
+        /// Indicates if the watchdog has been set and is busy waiting for a call completion Reset to be called or a timeout to occur.
+        /// </summary>
+        public static bool IsSet
+        {
+            get => WatchDogThreadID != 0;
+        }
+
+        /// <summary>
+        /// Indicates if the watchdog was cancelled due to a timeout
+        /// </summary>
+        public static bool IsCancelled
+        {
+            get => isCancelled_;
+        }
+
+        /// <summary>
+        /// The watchdog timeout timespan
+        /// </summary>
+        public static TimeSpan Timeout
+        {
+            get => timeout_;            
+            set
+            {
+                Enable(value);
+            }
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Enables the Watchdog mechanism. This can be called from any thread and does not have to be the DCOM call originator thread.
+        /// Uses the default call timeout.
+        /// </summary>
+        public static void Enable()
+        {
+            Enable(TimeSpan.FromSeconds(DEFAULT_TIMEOUT_SECONDS));
+        }
+
+
+        /// <summary>
+        /// Enables the Watchdog mechanism. This can be called from any thread and does not have to be the DCOM call originator thread.
+        /// </summary>
+        /// <param name="timeout">The maximum time to wait for a DCOM call to succeed before it is cancelled. Note that DCOM will typically timeout
+        /// between 1-2 minutes, depending on the OS</param>
+        public static void Enable(TimeSpan timeout)
+        {          
+            if (timeout == TimeSpan.Zero)
+            {
+                timeout = TimeSpan.FromSeconds(DEFAULT_TIMEOUT_SECONDS);
+            }
+
+            lock (watchdogLock_)
+            {
+                timeout_ = timeout;
+            }
+
+            watchdogTask_ = Task.Run(() => WatchdogTask());
+        }
+
+        /// <summary>
+        /// Disables the watchdog mechanism and stops any call cancellations.
+        /// </summary>
+        /// <returns>True if enabled and now disabled, otherwise false</returns>
+
+        public static bool Disable()
+        {
+            lock (watchdogLock_)
+            {
+                if (IsEnabled)
+                {
+                    timeout_ = TimeSpan.Zero;
+
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Sets the watchdog timer active on the current thread. If Reset is not called within the timeout period, any current thread DCOM call will be cancelled. The
+        /// calling thread must be the originator of the DCOM call and must be an STA thread.
+        /// </summary>
+        /// <returns>True if the watchdog set succeeds or was already set for the current thread, else false if the watchdog is not enabled.</returns>
+        public static bool Set()
+        {
+            if (IsEnabled)
+            {
+                ApartmentState apartmentState = Thread.CurrentThread.GetApartmentState();
+
+                if (apartmentState != ApartmentState.STA)
+                {
+                    throw new InvalidOperationException("COM calls can only be cancelled on a COM STA apartment thread - use [STAThread] attibute or set the state of the thread on creation");
+                }
+
+                lock (watchdogLock_)
+                {
+                    uint threadId = Interop.GetCurrentThreadId();
+
+                    if (IsSet)
+                    {
+                        if (threadId != watchDogThreadID_)
+                        {
+                            throw new InvalidOperationException($"Attempt to set call cancellation on different thread [{threadId}] to where it was already enabled [{watchDogThreadID_}]");
+                        }
+                    }
+                    else
+                    {
+                        isCancelled_ = false;
+                        watchDogThreadID_ = 0;
+                        lastWatchdogResult_ = DCOMWatchdogResult.None;
+
+                        //enable DCOM call cancellation for duration of the watchdog
+                        int hresult = Interop.CoEnableCallCancellation(IntPtr.Zero);
+
+                        if (hresult == 0)
+                        {
+                            setStart_ = DateTime.UtcNow;
+                            watchDogThreadID_ = threadId;
+                           
+                            Utils.Trace(Utils.TraceMasks.Information, $"COM call cancellation on thread [{watchDogThreadID_}] was set with timeout [{timeout_.TotalSeconds} seconds]");
+                        }
+                        else
+                        {
+                            throw new Exception($"Failed to set COM call cancellation (HResult = {hresult})");
+                        }
+                    }
+                }
+
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Refreshes the watchdog activity timer to now, effectively resetting the time to wait.
+        /// </summary>
+        /// <returns>True if the watchdog time was updated, else False if the watchdog timer is not Enabled or Set</returns>
+        public static bool Update()
+        {
+            if (IsEnabled)
+            {
+                lock (watchdogLock_)
+                {
+                    if (IsSet)
+                    {
+                        setStart_ = DateTime.UtcNow;
+
+                        return true;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Resets the watchdog timer for the current thread. This should be called after a DCOM call returns to indicate the call succeeded, and thus cancelling the
+        /// watchdog timer.
+        /// </summary>
+        /// <returns>True if the watchdog timer was reset for the current thread, else False if the timer was not set for the thread of the watchdog is not enabled.</returns>
+        public static bool Reset()
+        {
+            if (IsEnabled)
+            {
+                lock (watchdogLock_)
+                {
+                    if (IsSet)
+                    {
+                        uint threadId = Interop.GetCurrentThreadId();
+
+                        if (threadId == watchDogThreadID_)
+                        {
+                            if (!IsCancelled)
+                            {
+                                lastWatchdogResult_ = DCOMWatchdogResult.Completed;
+                            }
+
+                            watchDogThreadID_ = 0;
+                            isCancelled_ = false;
+
+                            //disable DCOM call cancellation 
+                            int hresult = Interop.CoDisableCallCancellation(IntPtr.Zero);
+
+                            Utils.Trace(Utils.TraceMasks.Information, $"COM call cancellation on thread [{watchDogThreadID_}] was reset [HRESULT = {hresult}]");
+                        }
+                        else
+                        {
+                            throw new Exception($"COM call cancellation cannot be reset from different thread [{threadId}] it was set on [{watchDogThreadID_}]");
+                        }
+                    }
+                }
+
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }   
+
+        /// <summary>
+        /// Allows for manual cancellation of the current DCOM call
+        /// </summary>
+        /// <returns></returns>
+        public static bool Cancel()
+        {
+            return Cancel(DCOMWatchdogResult.ManuallyCancelled);
+        }
+
+        /// <summary>
+        /// Cancels the current DCOM call if there is one active
+        /// </summary>
+        /// <param name="reason"></param>
+        /// <returns>The reason for the cancellation</returns>
+        private static bool Cancel(DCOMWatchdogResult reason)
+        {
+            if (IsEnabled)
+            {
+                lock (watchdogLock_)
+                {
+                    if (!IsCancelled && IsSet)
+                    {
+                        isCancelled_ = true;
+
+                        //cancel the current DCOM call immediately
+                        int hresult = Interop.CoCancelCall(watchDogThreadID_, 0);
+
+                        Utils.Trace(Utils.TraceMasks.Information, $"COM call on thread [{watchDogThreadID_}] was cancelled [HRESULT = {hresult}]");
+
+                        lastWatchdogResult_ = reason;
+
+                        return true;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// The Watchdog Task is a seperate thread that is activated when the Watchdog is enabled. It checks the time since the last Set was called and
+        /// then cancels the current DCOM call automatically if Reset is not called within the timeout period.
+        /// </summary>
+        private static void WatchdogTask()
+        {            
+            while (IsEnabled)
+            {
+                try
+                {
+                    if (IsSet & !IsCancelled)
+                    {
+                        if (TimeElapsed(setStart_) >= timeout_)
+                        {
+                            Utils.Trace(Utils.TraceMasks.Information, $"Sync call watchdog for thread [{watchDogThreadID_}] timed out - cancelling current call...");
+
+                            Cancel(DCOMWatchdogResult.TimedOut);
+                        }                        
+                    }
+                }
+                catch (Exception e)
+                {
+                    Utils.Trace(Utils.TraceMasks.Error, $"Error in Sync call watchdog thread : {e.ToString()}");
+                }
+                finally
+                {
+                    Thread.Sleep(1);
+                }
+            }
+        }
+
+        
+        private static TimeSpan TimeElapsed(DateTime startTime)
+        {
+            DateTime now = DateTime.UtcNow;
+
+            startTime = startTime.ToUniversalTime();
+
+            if (startTime > now)
+            {
+                return startTime - now;
+            }
+            else
+            {
+                return now - startTime;
+            }
+        }
+
+        #endregion
+
+    }       
+}

--- a/src/Technosoftware/DaAeHdaClient/Utilities/Interop.cs
+++ b/src/Technosoftware/DaAeHdaClient/Utilities/Interop.cs
@@ -451,6 +451,18 @@ namespace Technosoftware.DaAeHdaClient.Utilities
             public readonly int hr;
         }
 
+        [DllImport("ole32.dll")]
+        public static extern int CoCancelCall(uint threadId, uint timeout);
+
+        [DllImport("ole32.dll")]
+        public static extern int CoEnableCallCancellation(IntPtr reserved);
+
+        [DllImport("ole32.dll")]
+        public static extern int CoDisableCallCancellation(IntPtr reserved);
+
+        [DllImport("Kernel32.dll")]
+        public static extern uint GetCurrentThreadId();
+
         #endregion
 
         #endregion


### PR DESCRIPTION
An update to enable/disable DCOM call cancellation (CoEnableCallCancellation, CoDisableCallCancellation, CoCancelCall) to allow for the cancellation of DCOM calls that would otherwise wait the full “default” DCOM timeout period before the call fails. This is used most often when the client is attempting to connect to a server for example. However, the .net DA client binaries result in unusual behaviour if this is implemented externally (the connect does not fail immediately), which when traced using the source code is due to the way the synchronous call cancels the CoCreateInstanceEx call during connect. In this case, the call returns immediately on call cancellation but the HRESULT is SUCCESS and none of the CoCreateInstanceEx result parameters give an indication the call was cancelled. Additional logic is required that indicates if the call was cancelled is required to evaluate the DCOM call result thus allowing the result of the CoCreateInstanceEx to be handled differently in this case, such as throw an Exception for example. To implement this practically, one would need to implement a watchdog thread of sorts at the appropriate level in the .net client to handle call cancellation.

I have thus implemented such a call cancellation mechanism in the code and testing thus far indicates it operates as expected. There is one caveat in that it only works if the thread making the calls to be cancelled is explicitly defined as an STA thread apartment in .net– this is due to the CoEnableCallCancellation call, which internally takes the calling native thread ID to be the thread to enable the cancellation on. In .net we are not in direct control of this thread ID and thus, in MTA threading mode, the CoCancelCall fails as the retrieved native ThreadId is never the threadId on which the call cancellation was enabled. I, however, have not encountered any operational or performance issues in setting this STA requirement during my testing thus far.
